### PR TITLE
Replace deprecated `project` with projected type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,5 @@ categories = ["asynchronous"]
 [dependencies]
 actix = "0.9.0"
 scoped-tls-hkt = "0.1.2"
-pin-project = "0.4.9"
+pin-project = "0.4.21"
 futures = "0.3.4"


### PR DESCRIPTION
Ref: https://github.com/taiki-e/pin-project/blob/v0.4.21/CHANGELOG.md#0421---2020-06-13

---

Also open to migrating to `pin_project_lite` which is supposed to be lighter-weight, but as-is this was a pretty quick change.

Original error:
```
Compiling actix-interop v0.1.1 (/home/jon/src/oss/actix-interop)
error: use of deprecated item 'project': consider naming projected type by passing `project` argument to #[pin_project] attribute instead, see release note <https://github.com/taiki-e/pin-project/releases/tag/v0.4.21> for details
   --> src/local_handle.rs:54:7
    |
54  |     #[project]
    |       ^^^^^^^
    |
note: the lint level is defined here
   --> src/lib.rs:144:23
    |
144 | #![deny(missing_docs, warnings)]
    |                       ^^^^^^^^
    = note: `#[deny(deprecated)]` implied by `#[deny(warnings)]`
```