### PR TITLE
deps: update actix 0.9.0 -> 0.10.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["actix", "async", "await", "context", "atomic"]
 categories = ["asynchronous"]
 
 [dependencies]
-actix = "0.9.0"
+actix = "0.10.0"
 scoped-tls-hkt = "0.1.2"
 pin-project = "0.4.21"
 futures = "0.3.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-interop"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Diggory Blake <diggsey@googlemail.com>"]
 edition = "2018"
 license = "MIT/Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ convenient way to control access to an actor's state.
 ```toml
 # Cargo.toml
 [dependencies]
-actix-interop = "0.1"
+actix-interop = "0.2"
 ```
 
 # Example

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -251,7 +251,7 @@ pub trait FutureInterop<A: Actor>: Future + Sized {
     where
         Self: 'static,
     {
-        Box::new(self.interop_actor(actor))
+        Box::pin(self.interop_actor(actor))
     }
 }
 


### PR DESCRIPTION
Likely requires a minor version bump to `actix-interop` since the actix update is a breaking change. Happy to do it in this PR, or just leave it for now.

Original error when attempting to use with an actix 10 based project:
```
error[E0308]: mismatched types

...

254 | |         }.interop_actor_boxed(self)
    | |___________________________________^ expected struct `std::pin::Pin`, found struct `std::boxed::Box`
```