### PR TITLE
Fix the build

### DIFF
--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -1,4 +1,8 @@
-on: [push]
+on: 
+  push:
+    branches:
+      - master
+  pull_request:
 
 name: CI
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -337,7 +337,7 @@ mod tests {
         fn handle(&mut self, msg: Sum, _ctx: &mut Context<Self>) -> Self::Result {
             async move {
                 // Run some code with exclusive access to the actor
-                let accum = critical_section::<Self, _>(async {
+                let accum = critical_section::<Self, _>(async move {
                     with_ctx(move |a: &mut Self, _| {
                         a.field += msg.0;
                         a.field


### PR DESCRIPTION
Main item was adding `move` to the Summator's handle async bit, but I've also enabled "build on PR" to detect issues at that stage, not merge stage. https://github.com/palfrey/actix-interop/pull/1 demos the current situation, which notes that https://github.com/Diggsey/actix-interop/pull/8 broke the 1.40.0 build. Do you want to up that version, or revert the edition/actix changes?